### PR TITLE
Strong scaling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spatter"]
 	path = spatter
-	url = git@github.com:JDTruj2018/spatter.git
+	url = git@github.com:hpcgarage/spatter.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spatter"]
 	path = spatter
-	url = git@github.com:hpcgarage/spatter.git
+	url = git@github.com:JDTruj2018/spatter.git

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Strong-Scaling experiment on the CPU with core-binding (`-c`) turned on and plot
 bash scripts/scaling.sh -a flag -p static_2d -f 001 -n ATS3 -c
 ```
 
-Throughput experiment on the GPU (`-g`) with throughput plotting (`-t`), pattern truncating using the values in sizelist (`-s`), and multiple scatters/gathers using the values in countlist (`-r`). Results will be found in `spatter.strongscaling/A100/flag/static_2d/001` and Figures will be found in `figures/CTS1/flag/static_2d/001`.
+Throughput experiment on the GPU (`-g`) with throughput plotting (`-t`), pattern truncating using the values in sizelist (`-s`), and multiple scatters/gathers using the values in countlist (`-r`). Results will be found in `spatter.strongscaling/H100/flag/static_2d/001` and Figures will be found in `figures/spatter.strongscaling/H100/flag/static_2d/001`.
 
 ```
-bash scripts/scaling.sh -a flag -p static_2d -f 001 -n A100 -g -s -r -t
+bash scripts/scaling.sh -a flag -p static_2d -f 001 -n H100 -g -s -r -t
 ```
 
 The `scripts/mpirunscaling.sh` script has been provided if you need to use `mpirun` to launch jobs rather than `srun`.
@@ -118,7 +118,7 @@ The `scripts/mpirunscaling.sh` script has been provided if you need to use `mpir
 Simply update the `ranklist` variables in `scripts/config.sh` to the value of `( 1 )`
 
 ```
-bash scripts/scaling.sh -a flag -p static_2d -f 001 -n A100 -g
+bash scripts/scaling.sh -a flag -p static_2d -f 001 -n H100 -g
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,19 @@ Current options for Application name, Problem name, and Pattern name are listed 
 
 #### Examples
 
-Weak-Scaling experiment with core-binding turned on and plotting enabled. Boundary limiting will be disabled by default. Results will be found in `spatter.weakscaling/ATS3/flag/static_2d/001` and Figures will be found in 'figures/ATS3/flag/static_2d/001`.
+Weak-Scaling experiment (`-w`) on the CPU with core-binding (`-c`) turned on and plotting enabled (on by default). Results will be found in `spatter.weakscaling/ATS3/flag/static_2d/001` and Figures will be found in `figures/spatter.weakscaling/ATS3/flag/static_2d/001`.
 
 ```
 bash scripts/scaling.sh -a flag -p static_2d -f 001 -n ATS3 -c -w
 ```
 
-Throughput experiment with plotting enabled. Boundary limiting using the values in boundarylist and pattern truncating using the values in sizelist will be enabled by default. Results will be found in `spatter.strongscaling/A100/flag/static_2d/001` and Figures will be found in `figures/CTS1/flag/static_2d/001`.
+Strong-Scaling experiment on the CPU with core-binding (`-c`) turned on and plotting enabled (on by default). Results will be found in `spatter.strongscaling/ATS3/flag/static_2d/001` and Figures will be found in `figures/spatter.strongscaling/ATS3/flag/static_2d/001`.
+
+```
+bash scripts/scaling.sh -a flag -p static_2d -f 001 -n ATS3 -c
+```
+
+Throughput experiment on the GPU (`-g`) with throughput plotting (`-t`), pattern truncating using the values in sizelist (`-s`), and multiple scatters/gathers using the values in countlist (`-r`). Results will be found in `spatter.strongscaling/A100/flag/static_2d/001` and Figures will be found in `figures/CTS1/flag/static_2d/001`.
 
 ```
 bash scripts/scaling.sh -a flag -p static_2d -f 001 -n A100 -g -s -r -t
@@ -129,7 +135,7 @@ For GPU builds (CUDA), you need CMake, nvcc, gcc, and MPI
 
 #### Copy an existing Module Environment File
 For a base CPU Module file:
-`cp modules/darwin_skylake.mod modules/<name>.mod`
+`cp modules/ats3.mod modules/<name>.mod`
 
 For a base GPU Module file:
 `cp modules/darwin_a100.mod modules/<name>.mod`
@@ -149,7 +155,8 @@ vim scripts/gpu_config.sh
 - Change the MODULEFILE to your new module file (absolute path).
 - You may leave SPATTER unchanged unless you have another Spatter binary on your system. If so, you may update this variable to point to you Spatter binary.
 - Change ranklist as appropriate for your system. This sets the number of MPI ranks Spatter will scale through.
-- (STRONG SCALING ONLY) Change sizelist as appropriate for strong scaling experiments. This defines the pattern length to truncate at as we scale. The defaults provided should work for the provided patterns. Only change if you know what you are doing.
+- Change sizelist as appropriate for strong scaling experiments. This defines the pattern length to truncate at as we scale. The defaults provided should work for the provided patterns. Only change if you know what you are doing.
+- Change countlist as appropriate for strong scaling experiments. This defines the number of scatters/gathers to perform, each shifted by a default delta of 8. See hpcgarage/spatter for further documentation on the count and delta parameters.
 
 ### Building Spatter
 

--- a/README.md
+++ b/README.md
@@ -53,16 +53,15 @@ This setup script performs the following:
    - MODULEFILE is set to `modules/cpu.mod`
    - SPATTER is set to path of the Spatter CPU executable
    - ranklist is set to sweep from 1-112 ranks respectively for a ATS-3 type system
-   - boundarylist is set to reasonable defaults for strong scaling experiments (specifies the maximum value of a pattern index, limiting the size of the data array)
    - sizelist is set to reasonable defaults for strong scaling experiments (specifies the size of the pattern to truncate at)
+   - countlist is set to defaults of 1.
 5. Populates the GPU configuration file (`scripts/gpu_config.sh`) with reasonable defaults for single-GPU throughput experiments on a V100 or A100 system
    - HOMEDIR is set to the directory this repository sits in
    - MODULEFILE is set to `modules/gpu.mod`
    - SPATTER is set to path of the Spatter GPU executable
    - ranklist is set to a constant of 1 for 8 different runs (8 single-GPU runs)
-   - boundarylist is set to reasonable defaults for throughput experiments (specifies the maximum value of a pattern index, limiting the size of the data array)
    - sizelist is set to reasonable defaults for throughput experiments (specifies the size of the pattern to truncate at)
-   - countlist is set to reasonable defaults to control the number of gathers/             scatters performed by an experiment. This is the parameter that is varied to perform       throughput experiments.
+   - countlist is set to reasonable defaults to control the number of gathers/scatters performed by an experiment. This is the parameter that is varied to perform throughput experiments.
 6. Attempts to build Spatter on CPU with CMake, GCC, and MPI and on GPU with CMake and nvcc
    - You will need CMake, GCC, and MPI loaded into your environment for the CPU build (include them in your `modules/cpu.mod`)
    - You will need CMake, cuda, and nvcc loaded into your environment for the GPU build (include them in your `modules/gpu.mod`)
@@ -76,9 +75,9 @@ The `scripts/scaling.sh` script has the following options:
 - p: Problem name
 - f: Pattern name
 - n: User-defined run name (for saving results)
-- b: Toggle boundary limit (option, default: off for weak scaling, will be overridden to on for strong scaling)
 - c: Core binding (optional, default: off)
 - g: Toggle GPU (optional, default: off)
+- r: Toggle count parameter on pattern with countlist (default: off)
 - s: Toggle pattern size limit (optional, default: off for weak scaling, will be overridden to on for strong scaling)
 - t: Toggle throughput plot generation (optional, default: off)
 - w: Toggle weak/strong scaling (optional, default: off = strong scaling)
@@ -104,7 +103,7 @@ bash scripts/scaling.sh -a flag -p static_2d -f 001 -n ATS3 -c -w
 Throughput experiment with plotting enabled. Boundary limiting using the values in boundarylist and pattern truncating using the values in sizelist will be enabled by default. Results will be found in `spatter.strongscaling/A100/flag/static_2d/001` and Figures will be found in `figures/CTS1/flag/static_2d/001`.
 
 ```
-bash scripts/scaling.sh -a xrage -p static_2d -f 001 -n A100 -g -s -t
+bash scripts/scaling.sh -a flag -p static_2d -f 001 -n A100 -g -s -r -t
 ```
 
 The `scripts/mpirunscaling.sh` script has been provided if you need to use `mpirun` to launch jobs rather than `srun`.
@@ -150,7 +149,6 @@ vim scripts/gpu_config.sh
 - Change the MODULEFILE to your new module file (absolute path).
 - You may leave SPATTER unchanged unless you have another Spatter binary on your system. If so, you may update this variable to point to you Spatter binary.
 - Change ranklist as appropriate for your system. This sets the number of MPI ranks Spatter will scale through.
-- Change the boundarylist as appropriate for scaling experiments. This defines the largest index that can exist in the pattern array. Any indices larger will be truncated by x % boundary. This in turn, limits the size of the data array, since it has extent max(pattern). Only change if you know what you are doing.
 - (STRONG SCALING ONLY) Change sizelist as appropriate for strong scaling experiments. This defines the pattern length to truncate at as we scale. The defaults provided should work for the provided patterns. Only change if you know what you are doing.
 
 ### Building Spatter

--- a/scripts/mpirunscaling.sh
+++ b/scripts/mpirunscaling.sh
@@ -6,10 +6,10 @@ usage() {
 		-p : Specify the name of the input problem (see available problems in the application sub-directory)
 		-f : Specify the base name of the input JSON file containing the gather/scatter pattern (see available patterns in the input problem subdirectory)
 		-n : Specify the test name you would like to use to identify this run (used to appropriately save data)
-		-b : Optional, toggle boundary limit on pattern with boundarylist (default: off for weak scaling, will be overrridden to on for strong scaling)
 		-c : Optional, toggle core binding (default: off)
 		-g : Optional, toggle gpu (default: off/cpu)
-		-s : Optional, toggle pattern size limit on pattern with sizelist (default: off for weak scaling, will be overridden to on for strong scaling)
+		-r : Optional, toggle count parameter on pattern with countlist (default: off)
+		-s : Optional, toggle pattern size limit on pattern with sizelist (default: off)
 		-t : Optional, toggle throughput plot generation (optional, default: off)
 		-w : Optional, enable weak scaling (default: off, strong scaling)
 		-x : Optional, toggle plotting/post-processing. Requires python3 environment with pandas, matplotlib (default: on)"
@@ -22,15 +22,13 @@ else
         WEAKSCALING=0
 	PLOT=1
 	BINDING=0
-	BOUNDARY=0
+	COUNT=0
 	PSIZE=0
 	GPU=0
 	THROUGHPUT=0
-	while getopts "a:f:p:n:bcgstwx" opt; do
+	while getopts "a:f:p:n:cgrstwx" opt; do
 		case $opt in 
 			a) APP=$OPTARG
-			;;
-			b) BOUNDARY=1
 			;;
 			f) PATTERN=$OPTARG
 			;;
@@ -41,6 +39,8 @@ else
 			c) BINDING=1
 			;;
 			g) GPU=1
+			;;
+			r) COUNT=1
 			;;
 			s) PSIZE=1
 			;;
@@ -76,37 +76,27 @@ else
 	fi
 	echo "THROUGHPUT PLOTS: ${THROUGHPUT}"
 
-	if [[ "${WEAKSCALING}" -ne "1" ]]; then
-		echo "Strong Scaling run, turning on boundary size and pattern size"
-		BOUNDARY=1
-		PSIZE=1
-	fi
-
         if [[ "${WEAKSCALING}" -eq "1" ]]; then
                	echo "Weak Scaling"	
-		echo "BOUNDARY: ${BOUNDARY}"
-		if [[ "${BOUNDARY}" -eq "1" ]]; then
-			echo "BOUNDARY LIST: ${boundarylist[*]}"
-		fi
-		echo "PATTERN SIZE: ${PSIZE}"
-		if [[ "${PSIZE}" -eq "1" ]]; then
-			echo "PATTERN SIZE LIST: ${sizelist[*]}"
-		fi
 		SCALINGDIR="spatter.weakscaling"
 	else
                	echo "Strong Scaling"
-		echo "BOUNDARY: ${BOUNDARY}"
-		echo "BOUNDARY LIST: ${boundarylist[*]}"
-		echo "PATTERN SIZE: ${PSIZE}"
-		echo "PATTERN SIZE LIST: ${sizelist[*]}"
 		SCALINGDIR="spatter.strongscaling"
 	fi
 
 	if [[ "${GPU}" -eq "1" ]]; then
 		echo "GPU Run, turning off core binding"
 		BINDING=0
-		echo "GPU Run, Enabling countlist"
+	fi
+
+	echo "COUNT: ${COUNT}"
+	if [[ "${COUNT}" -eq "1" ]]; then
 		echo "COUNT LIST: ${countlist[*]}"
+	fi
+
+	echo "PATTERN SIZE: ${PSIZE}"
+	if [[ "${PSIZE}" -eq "1" ]]; then
+		echo "PATTERN SIZE LIST: ${sizelist[*]}"
 	fi
 
 	echo "RANK LIST: ${ranklist[*]}"
@@ -129,80 +119,42 @@ else
 	cd ${SCALINGDIR}/${RUNNAME}/${APP}/${PROBLEM}/${PATTERN}
 
 	for i in ${!ranklist[*]}; do
+
+		cp ${JSON} ${JSON}.orig
+
 		CFILE="_c1"
 		SFILE="_s0"
+
+		if [[ "${COUNT}" -eq "1" ]]; then
+			CFILE="_${countlist[i]}c"
+			sed -Ei 's/"count":1/"count": '${countlist[i]}'/g' ${JSON}
+		fi
+
+		if [[ "${PSIZE}" -eq "1" ]]; then
+			SFILE="_${sizelist[i]}s"
+			sed -Ei 's/\}/\, "pattern-size": '${sizelist[i]}'\}/g' ${JSON}
+		fi
+
+		if [[ "${GPU}" -eq "1" ]]; then
+			sed -Ei 's/\}/\, "local-work-size": 1024\}/g' ${JSON}
+		fi
 
 		# Core Binding
 		if [[ "${BINDING}" -eq "1" ]]; then	
 			CMD="mpirun -n ${ranklist[i]} --bind-to=core ${SPATTER} -pFILE=${JSON} -q3"
-			cp ${JSON} ${JSON}.orig
 		
-			if [[ "${GPU}" -eq "1" ]]; then
-				sed -Ei 's/\}/\, "local-work-size": 1024\}/g' ${JSON}
-			fi
-	
 			# Strong Scaling
 			if [[ "${WEAKSCALING}" -ne "1" ]]; then
-				sed -Ei 's/\}/\, "pattern-size": '${sizelist[i]}'\}/g' ${JSON}
-				SFILE="_${sizelist[i]}s"
-
-				if [[ "${GPU}" -eq "1" ]]; then
-					CFILE="_${countlist[i]}c"
-					sed -Ei 's/"count":1/"count": '${countlist[i]}'/g' ${JSON}
-				fi
-
-				sed -Ei 's/\}/\, "boundary": '${boundarylist[i]}'\}/g' ${JSON}
-			# Weak Scaling
-			else
-				if [[ "${PSIZE}" -eq "1" ]]; then
-					SFILE="_${sizelist[i]}s"
-					sed -Ei 's/\}/\, "pattern-size": '${sizelist[i]}'\}/g' ${JSON}
-				fi
-				
-				if [[ "${GPU}" -eq "1" ]]; then
-					CFILE="_${countlist[i]}c"
-					sed -Ei 's/"count":1/"count": '${countlist[i]}'/g' ${JSON}
-				fi
-				
-				if [[ "${BOUNDARY}" -eq "1" ]]; then
-					sed -Ei 's/\}/\, "boundary": '${boundarylist[i]}'\}/g' ${JSON}
-				fi
+ 				sed -Ei 's/\}/\, "strong-scale": 1\}/g' ${JSON}
 			fi
+
 		# No Core Binding
 		else
 			CMD="mpirun -n ${ranklist[i]} ${SPATTER} -pFILE=${JSON} -q3"
-			cp ${JSON} ${JSON}.orig
-			
-			if [[ "${GPU}" -eq "1" ]]; then
-				sed -Ei 's/\}/\, "local-work-size": 1024\}/g' ${JSON}
-			fi
 
 			# Strong Scaling
 			if [[ "${WEAKSCALING}" -ne "1" ]]; then
-				SFILE="_${sizelist[i]}s"
-				sed -Ei 's/\}/\, "pattern-size": '${sizelist[i]}'\}/g' ${JSON}
-
-				if [[ "${GPU}" -eq "1" ]]; then
-					CFILE="_${countlist[i]}c"
-					sed -Ei 's/"count":1/"count": '${countlist[i]}'/g' ${JSON}
-				fi
-
-				sed -Ei 's/\}/\, "boundary": '${boundarylist[i]}'\}/g' ${JSON}
-			# Weak Scaling
-			else	
-				if [[ "${PSIZE}" -eq "1" ]]; then
-					SFILE="_${sizelist[i]}s"
-					sed -Ei 's/\}/\, "pattern-size": '${sizelist[i]}'\}/g' ${JSON}
-				fi
-
-				if [[ "${GPU}" -eq "1" ]]; then
-					CFILE="_${countlist[i]}c"
-					sed -Ei 's/"count":1/"count": '${countlist[i]}'/g' ${JSON}
-				fi
-
-				if [[ "${BOUNDARY}" -eq "1" ]]; then
-					sed -Ei 's/\}/\, "boundary": '${boundarylist[i]}'\}/g' ${JSON}
-				fi
+				sed -Ei 's/\}/\, "strong-scale": 1\}/g' ${JSON}
 			fi
 		fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,8 +59,8 @@ if [[ "${CPUBUILD}" -eq "1" ]]; then
 	sed -i "s|SPATTER=.*|SPATTER=$HOMEDIR\/spatter\/build_omp_mpi_gnu\/spatter|g" scripts/cpu_config.sh
 
 	sed -i "s|ranklist=.*|ranklist=\( 1 2 4 8 16 32 56 64 96 112 \)|g" scripts/cpu_config.sh
-	sed -i "s|boundarylist=.*|boundarylist=\( 81920 40960 20480 10240 5120 2560 1463 1280 853 731 \)|g" scripts/cpu_config.sh
 	sed -i "s|sizelist=.*|sizelist=\( 16384 8192 4096 2048 1024 512 293 256 171 146 \)|g" scripts/cpu_config.sh
+	sed -i "s|countlist=.*|countlist=\( 1 1 1 1 1 1 1 1 1 1 \)|g" scripts/cpu_config.sh
 	echo ""
 
 	echo "Building Spatter on CPU..."
@@ -74,7 +74,6 @@ if [[ "${GPUBUILD}" -eq "1" ]]; then
 	sed -i "s|SPATTER=.*|SPATTER=$HOMEDIR\/spatter\/build_cuda\/spatter|g" scripts/gpu_config.sh
 
 	sed -i "s|ranklist=.*|ranklist=\( 1 1 1 1 1 1 1 1 1 1 1 1\)|g" scripts/gpu_config.sh
-	sed -i "s|boundarylist=.*|boundarylist=\( 81920 81920 81920 81920 81920 81920 81920 81920 81920 81920 81920 81920 \)|g" scripts/gpu_config.sh
 	sed -i "s|sizelist=.*|sizelist=\( 524288 1048576 2097152 4194304 8388608 8388608 8388608 8388608 8388608 8388608 8388608 8388608 \)|g" scripts/gpu_config.sh
 	sed -i "s|countlist=.*|countlist=\( 1 1 1 1 1 2 4 8 16 32 64 128 \)|g" scripts/gpu_config.sh	
 


### PR DESCRIPTION
Spatter submodule now points at the `JDTruj2018/strong-scaling` branch while the PR to Spatter waits for approval.

Removed the `-b` flag and references to the `boundarylist` for now (see `scripts/scaling.sh`).

Added `-c` flag to toggle using the `countlist` to set the count parameter in the JSON file before it is passed to Spatter. The count parameter sets the number of times to loop through the scatter/gather pattern, where each iteration the pattern is offset by some delta (see `scripts/scaling.sh`).

When strong-scaling is enabled, add `, strong-scale: 1}` to the end of the JSON file to let Spatter know to perform strong-scaling by splitting the pattern across ranks as evenly as possible (see `scripts/scaling.sh`).

Some associated changes in `scripts/setup.sh` to remove references to `boundarylist`, etc.