### PR TITLE
Atomics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spatter"]
 	path = spatter
-	url = git@github.com:JDTruj2018/spatter.git
+	url = git@github.com:hpcgarage/spatter.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spatter"]
 	path = spatter
-	url = git@github.com:hpcgarage/spatter.git
+	url = git@github.com:JDTruj2018/spatter.git

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The `scripts/scaling.sh` script has the following options:
 - n: User-defined run name (for saving results)
 - c: Core binding (optional, default: off)
 - g: Toggle GPU (optional, default: off)
+- m: Toggle Atomics (optional, default: off)
 - r: Toggle count parameter on pattern with countlist (default: off)
 - s: Toggle pattern size limit (optional, default: off for weak scaling, will be overridden to on for strong scaling)
 - t: Toggle throughput plot generation (optional, default: off)
@@ -106,10 +107,10 @@ Strong-Scaling experiment on the CPU with core-binding (`-c`) turned on and plot
 bash scripts/scaling.sh -a flag -p static_2d -f 001 -n ATS3 -c
 ```
 
-Throughput experiment on the GPU (`-g`) with throughput plotting (`-t`), pattern truncating using the values in sizelist (`-s`), and multiple scatters/gathers using the values in countlist (`-r`). Results will be found in `spatter.strongscaling/H100/flag/static_2d/001` and Figures will be found in `figures/spatter.strongscaling/H100/flag/static_2d/001`.
+Throughput experiment on the GPU (`-g`) with throughput plotting (`-t`) and atomics enabled (`-m`), pattern truncating using the values in sizelist (`-s`), and multiple scatters/gathers using the values in countlist (`-r`). Results will be found in `spatter.strongscaling/H100/flag/static_2d/001` and Figures will be found in `figures/spatter.strongscaling/H100/flag/static_2d/001`.
 
 ```
-bash scripts/scaling.sh -a flag -p static_2d -f 001 -n H100 -g -s -r -t
+bash scripts/scaling.sh -a flag -p static_2d -f 001 -n H100 -g -s -r -t -m
 ```
 
 The `scripts/mpirunscaling.sh` script has been provided if you need to use `mpirun` to launch jobs rather than `srun`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The `scripts/mpirunscaling.sh` script has been provided if you need to use `mpir
 Simply update the `ranklist` variables in `scripts/config.sh` to the value of `( 1 )`
 
 ```
-bash scripts/scaling.sh -a flag -p static_2d -f 001 -n H100 -g
+bash scripts/scaling.sh -a flag -p static_2d -f 001 -n H100 -g -m
 ```
 
 

--- a/scripts/mpirunscaling.sh
+++ b/scripts/mpirunscaling.sh
@@ -28,7 +28,7 @@ else
 	PSIZE=0
 	GPU=0
 	THROUGHPUT=0
-	while getopts "a:f:p:n:cgrstwx" opt; do
+	while getopts "a:f:p:n:cgmrstwx" opt; do
 		case $opt in 
 			a) APP=$OPTARG
 			;;

--- a/scripts/mpirunscaling.sh
+++ b/scripts/mpirunscaling.sh
@@ -8,6 +8,7 @@ usage() {
 		-n : Specify the test name you would like to use to identify this run (used to appropriately save data)
 		-c : Optional, toggle core binding (default: off)
 		-g : Optional, toggle gpu (default: off/cpu)
+                -m : Optional, toggle atomics (default: off/no atomics)
 		-r : Optional, toggle count parameter on pattern with countlist (default: off)
 		-s : Optional, toggle pattern size limit on pattern with sizelist (default: off)
 		-t : Optional, toggle throughput plot generation (optional, default: off)
@@ -21,6 +22,7 @@ else
         SCALINGDIR="spatter.scaling"
         WEAKSCALING=0
 	PLOT=1
+        ATOMIC=0
 	BINDING=0
 	COUNT=0
 	PSIZE=0
@@ -40,6 +42,8 @@ else
 			;;
 			g) GPU=1
 			;;
+                        m) ATOMIC=1
+                        ;;
 			r) COUNT=1
 			;;
 			s) PSIZE=1
@@ -69,6 +73,7 @@ else
 	echo "PATTERN: ${PATTERN}"
 	echo "RUNNAME: ${RUNNAME}"
 	echo "GPU: ${GPU}"
+        echo "ATOMIC: ${ATOMIC}"
 	echo "PLOTTING: ${PLOT}"
 	if [[ "${PLOT}" -ne "1" ]]; then
 		echo "Plotting disabled, turning off throughput plots"
@@ -142,7 +147,12 @@ else
 		# Core Binding
 		if [[ "${BINDING}" -eq "1" ]]; then	
 			CMD="mpirun -n ${ranklist[i]} --bind-to=core ${SPATTER} -pFILE=${JSON} -q3"
-		
+
+			# Atomics
+			if [[ "${ATOMIC}" -ne "0" ]]; then
+ 				sed -Ei 's/\}/\, "atomic-writes": 1\}/g' ${JSON}
+			fi
+	
 			# Strong Scaling
 			if [[ "${WEAKSCALING}" -ne "1" ]]; then
  				sed -Ei 's/\}/\, "strong-scale": 1\}/g' ${JSON}
@@ -152,6 +162,11 @@ else
 		else
 			CMD="mpirun -n ${ranklist[i]} ${SPATTER} -pFILE=${JSON} -q3"
 
+			# Atomics
+			if [[ "${ATOMIC}" -ne "0" ]]; then
+ 				sed -Ei 's/\}/\, "atomic-writes": 1\}/g' ${JSON}
+			fi
+	
 			# Strong Scaling
 			if [[ "${WEAKSCALING}" -ne "1" ]]; then
 				sed -Ei 's/\}/\, "strong-scale": 1\}/g' ${JSON}

--- a/scripts/scaling.sh
+++ b/scripts/scaling.sh
@@ -8,6 +8,7 @@ usage() {
 		-n : Specify the test name you would like to use to identify this run (used to appropriately save data)
 		-c : Optional, toggle core binding (default: off)
 		-g : Optional, toggle gpu (default: off/cpu)
+                -m : Optional, toggle atomics (default: off/no atomics)
 		-r : Optional, toggle count parameter on pattern with countlist (default: off)
 		-s : Optional, toggle pattern size limit on pattern with sizelist (default: off)
 		-t : Optional, toggle throughput plot generation (optional, default: off)
@@ -21,6 +22,7 @@ else
         SCALINGDIR="spatter.scaling"
         WEAKSCALING=0
 	PLOT=1
+        ATOMIC=0
 	BINDING=0
 	COUNT=0
 	PSIZE=0
@@ -40,6 +42,8 @@ else
 			;;
 			g) GPU=1
 			;;
+                        m) ATOMIC=1
+                        ;;
 			r) COUNT=1
 			;;
 			s) PSIZE=1
@@ -69,6 +73,7 @@ else
 	echo "PATTERN: ${PATTERN}"
 	echo "RUNNAME: ${RUNNAME}"
 	echo "GPU: ${GPU}"
+        echo "ATOMIC: ${ATOMIC}"
 	echo "PLOTTING: ${PLOT}"
 	if [[ "${PLOT}" -ne "1" ]]; then
 		echo "Plotting disabled, turning off throughput plots"
@@ -142,7 +147,12 @@ else
 		# Core Binding
 		if [[ "${BINDING}" -eq "1" ]]; then	
 			CMD="srun -n ${ranklist[i]} --cpu-bind=core ${SPATTER} -pFILE=${JSON} -q3"
-		
+
+			# Atomics
+			if [[ "${ATOMIC}" -ne "0" ]]; then
+ 				sed -Ei 's/\}/\, "atomic-writes": 1\}/g' ${JSON}
+			fi
+	
 			# Strong Scaling
 			if [[ "${WEAKSCALING}" -ne "1" ]]; then
  				sed -Ei 's/\}/\, "strong-scale": 1\}/g' ${JSON}
@@ -152,6 +162,11 @@ else
 		else
 			CMD="srun -n ${ranklist[i]} ${SPATTER} -pFILE=${JSON} -q3"
 
+			# Atomics
+			if [[ "${ATOMIC}" -ne "0" ]]; then
+ 				sed -Ei 's/\}/\, "atomic-writes": 1\}/g' ${JSON}
+			fi
+	
 			# Strong Scaling
 			if [[ "${WEAKSCALING}" -ne "1" ]]; then
 				sed -Ei 's/\}/\, "strong-scale": 1\}/g' ${JSON}

--- a/scripts/scaling.sh
+++ b/scripts/scaling.sh
@@ -28,7 +28,7 @@ else
 	PSIZE=0
 	GPU=0
 	THROUGHPUT=0
-	while getopts "a:f:p:n:cgrstwx" opt; do
+	while getopts "a:f:p:n:cgmrstwx" opt; do
 		case $opt in 
 			a) APP=$OPTARG
 			;;


### PR DESCRIPTION
Add `-m` flag to enable Spatter write atomics during scaling runs. Write atomics only implemented for CUDA backend.